### PR TITLE
Update spring dependency

### DIFF
--- a/spring-commands-rubocop.gemspec
+++ b/spring-commands-rubocop.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'spring-commands-rubocop'
-  spec.version       = '0.3.0'
+  spec.version       = '0.4.0'
   spec.author        = 'Alex Rodionov'
   spec.email         = 'p0deje@gmail.com'
   spec.description   = 'RuboCop command for Spring'
@@ -16,6 +16,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'spring', '>= 1.0', '< 4.0'
+  spec.add_dependency 'spring', '>= 1.0'
   spec.add_development_dependency 'rake'
 end


### PR DESCRIPTION
Spring 4 has just come out. And so soon after the release of Spring 3.

I use other similar spring commands in my app: `spring-commands-cucumber`, [spring-commands-rspec](https://github.com/jonleighton/spring-commands-rspec/blob/182b21b9f03e22e8591e5a2029a5d0d16d4d3d93/spring-commands-rspec.gemspec#L20), and [spring-commands-thor](https://github.com/chanakasan/spring-commands-thor/blob/e25c920877231ad1ddc85fd9fc78f28baa870f2a/spring-commands-thor.gemspec#L20). None of these gems constrain the maximum version of spring. I imagine that we could do the same.

_Appeal to authority_: the spring commands `spring-commands-cucumber` and `spring-commands-rspec` were written by [Jon Leighton](https://github.com/jonleighton) who is the original author of spring. 

My guess is that if the protocol for spring commands  changes everyone will have to update their spring commands. So no risk to removing the maximum spring version specification in [spring-commands-rubocop.gemspec](https://github.com/toptal/spring-commands-rubocop/blob/2a700258eb527ed42c42e708d8e675a673780cea/spring-commands-rubocop.gemspec#L19).